### PR TITLE
Adjust when gpg_verify errors for missing keys

### DIFF
--- a/R/signing.R
+++ b/R/signing.R
@@ -24,11 +24,15 @@ gpg_verify <- function(signature, data = NULL, error = TRUE){
   out <- .Call(R_gpgme_verify, sig, data)
   out <- data.frame(out, stringsAsFactors = FALSE)
   if(isTRUE(error) && !any(out$success)){
+    # NB: out$fingerprint corresponds to gpg_list_keys()$id,
+    # not gpg_list_keys()$fingerprint.
     fp_failed <- out$fingerprint[!(out$success)]
-    stop("Verification failed. None of the pubkeys not found in keyring: ", paste(fp_failed, collapse = ", "), call. = FALSE)
-  } else {
-    out
-  }
+    unknown_keys <- setdiff(fp_failed, gpg_list_keys()$id)
+    if (length(unknown_keys) > 0) {
+      stop("Verification failed because pubkeys not found in keyring: ",
+        paste(unknown_keys, collapse = ", "), call. = FALSE)
+    }
+  out
 }
 
 #' @useDynLib gpg R_gpg_sign


### PR DESCRIPTION
Very cool package!

This is a minor tweak to `gpg_verify`. Previously, `gpg_verify(..., error = TRUE)` would give an error about missing keys when verification failed, even if the key was present, which made for a confusing error message.

Am I misinterpreting the `error` parameter?  Did you want it to give an error whenever verification failed, or just when it failed because of a missing key?