### PR TITLE
detect 32-bit Raspbian OS (armv7l) and add C flag

### DIFF
--- a/configure
+++ b/configure
@@ -44,6 +44,10 @@ if [ "$CHECK_OLD_GPGME" ]; then
   PKG_CFLAGS="$PKG_CFLAGS -DCHECK_OLD_GPGME"
 fi
 
+if [ `uname -m` = "armv7l" ]; then
+  PKG_CFLAGS="$PKG_CFLAGS -D_FILE_OFFSET_BITS=64"
+fi
+
 # For debugging
 echo "Using PKG_CFLAGS=$PKG_CFLAGS"
 echo "Using PKG_LIBS=$PKG_LIBS"


### PR DESCRIPTION
This fixes issue https://github.com/jeroen/gpg/issues/15 for a Raspberry Pi 4 running a 32-bit Raspbian OS (armv7l) with the method described in:

https://www.gnupg.org/documentation/manuals/gpgme/Largefile-Support-_0028LFS_0029.html

"If you do not use Autoconf, you can define the preprocessor symbol _FILE_OFFSET_BITS to 64 before including any header files, for example by specifying the option -D_FILE_OFFSET_BITS=64 on the compiler command line."